### PR TITLE
draft SPARQL endpoint

### DIFF
--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       - name: Coveralls
-        run: coveralls
+        run: coveralls --service=github
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/builds/deploy/triple-store/README.md
+++ b/builds/deploy/triple-store/README.md
@@ -1,0 +1,21 @@
+# PheKnowLator SPARQL Endpoint
+
+The files in this directory facilitate the hosting of a PheKnowLator knowledge graph via a SPARQL Endpoint. The [DBCLS SPARQL Proxy Web Application](https://github.com/dbcls/sparql-proxy) is used as the front end, and the data is served from a [Blazegraph](https://github.com/blazegraph/database) triple store.
+
+## Requirements
+* [docker-compose](https://docs.docker.com/compose)
+
+## Installation
+1. Check out this repository
+```
+git clone https://github.com/callahantiff/PheKnowLator.git ./pheknowlator.git
+cd ./pheknowlator.git/builds/deploy/triple-store
+```
+1. Build & launch the application
+```
+docker-compose build
+docker-compose up
+```
+
+## Access
+Once installed, visit `http://HOST_URL/sparql`, where `HOST_URL` is the URL of the host machine. If running locally, this will likely be http://localhost/sparql. If needed, the host port can be configured in the docker-compose.yml file.

--- a/builds/deploy/triple-store/backend/Dockerfile
+++ b/builds/deploy/triple-store/backend/Dockerfile
@@ -1,0 +1,27 @@
+FROM openkbs/blazegraph:latest
+
+USER root
+
+# the following supplants the existing RWStore.properties file
+COPY RWStore.properties /home/developer/blazegraph/conf
+COPY log4j.properties /home/developer/blazegraph/conf
+COPY run-loader.sh /
+COPY pom-blazegraph-loader.xml /
+
+RUN chmod 755 /run-loader.sh && \
+    mkdir /blazegraph-data && \
+    ln -s /usr/jdk1.8.0_191/bin/java /usr/bin/java
+
+# install the dependencies for the blazegraph loader
+RUN mvn package -f /pom-blazegraph-loader.xml
+
+RUN mkdir /pkt-data
+WORKDIR /pkt-data
+
+# Download & load the pheknowlator n-triples
+RUN wget http://purl.obolibrary.org/obo/cl.owl
+RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f rdfxml -r pheknowlator -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/cl.owl
+
+RUN chown -R developer:developer /blazegraph-data
+USER developer
+CMD ["java", "-server", "-Xmx10g", "-jar", "-Dbigdata.propertyFile=/home/developer/blazegraph/conf/RWStore.properties", "/home/developer/blazegraph/blazegraph.jar"]

--- a/builds/deploy/triple-store/backend/Dockerfile
+++ b/builds/deploy/triple-store/backend/Dockerfile
@@ -21,7 +21,9 @@ WORKDIR /pkt-data
 # Download & load the pheknowlator n-triples
 RUN wget https://storage.googleapis.com/pheknowlator/release_v2.0.0/current_build/knowledge_graphs/subclass_builds/inverse_relations/owlnets/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f ntriples -r pheknowlator -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
+RUN rm /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 
 RUN chown -R developer:developer /blazegraph-data
+RUN chown -R developer:developer /home/developer
 USER developer
-CMD ["java", "-server", "-Xmx10g", "-jar", "-Dbigdata.propertyFile=/home/developer/blazegraph/conf/RWStore.properties", "/home/developer/blazegraph/blazegraph.jar"]
+CMD ["java", "-server", "-Xmx10g", "-jar", "-Dbigdata.propertyFile=/home/developer/blazegraph/conf/RWStore.properties", "-Djetty.start.timeout=3600000", "/home/developer/blazegraph/blazegraph.jar"]

--- a/builds/deploy/triple-store/backend/Dockerfile
+++ b/builds/deploy/triple-store/backend/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /pkt-data
 
 # Download & load the pheknowlator n-triples
 RUN wget https://storage.googleapis.com/pheknowlator/release_v2.0.0/current_build/knowledge_graphs/subclass_builds/inverse_relations/owlnets/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
-RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f ntriples -r pheknowlator -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
+RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f ntriples -r kb -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 RUN rm /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 
 COPY override-web.xml /home/developer/

--- a/builds/deploy/triple-store/backend/Dockerfile
+++ b/builds/deploy/triple-store/backend/Dockerfile
@@ -23,7 +23,9 @@ RUN wget https://storage.googleapis.com/pheknowlator/release_v2.0.0/current_buil
 RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f ntriples -r pheknowlator -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 RUN rm /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 
+COPY override-web.xml /home/developer/
+
 RUN chown -R developer:developer /blazegraph-data
 RUN chown -R developer:developer /home/developer
 USER developer
-CMD ["java", "-server", "-Xmx32g", "-jar", "-Dbigdata.propertyFile=/home/developer/blazegraph/conf/RWStore.properties", "-Djetty.start.timeout=3600000", "/home/developer/blazegraph/blazegraph.jar"]
+CMD ["java", "-server", "-Xmx32g", "-jar", "-Dbigdata.propertyFile=/home/developer/blazegraph/conf/RWStore.properties", "-Djetty.start.timeout=3600000" , "-Djetty.overrideWebXml=/home/developer/override-web.xml", "/home/developer/blazegraph/blazegraph.jar"]

--- a/builds/deploy/triple-store/backend/Dockerfile
+++ b/builds/deploy/triple-store/backend/Dockerfile
@@ -19,8 +19,8 @@ RUN mkdir /pkt-data
 WORKDIR /pkt-data
 
 # Download & load the pheknowlator n-triples
-RUN wget http://purl.obolibrary.org/obo/cl.owl
-RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f rdfxml -r pheknowlator -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/cl.owl
+RUN wget https://storage.googleapis.com/pheknowlator/release_v2.0.0/current_build/knowledge_graphs/subclass_builds/inverse_relations/owlnets/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
+RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f ntriples -r pheknowlator -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 
 RUN chown -R developer:developer /blazegraph-data
 USER developer

--- a/builds/deploy/triple-store/backend/Dockerfile
+++ b/builds/deploy/triple-store/backend/Dockerfile
@@ -1,5 +1,4 @@
 FROM openkbs/blazegraph:latest
-
 USER root
 
 # the following supplants the existing RWStore.properties file
@@ -18,11 +17,12 @@ RUN mvn package -f /pom-blazegraph-loader.xml
 RUN mkdir /pkt-data
 WORKDIR /pkt-data
 
-# Download & load the pheknowlator n-triples
+# download & load the pheknowlator n-triples
 RUN wget https://storage.googleapis.com/pheknowlator/release_v2.0.0/current_build/knowledge_graphs/subclass_builds/inverse_relations/owlnets/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 RUN /run-loader.sh -z /home/developer/blazegraph/conf/log4j.properties -g file://pheknowlator -f ntriples -r kb -p /home/developer/blazegraph/conf/RWStore.properties -m mvn -l /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 RUN rm /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.nt
 
+# add file needed to ensure endpoint is read-only
 COPY override-web.xml /home/developer/
 
 RUN chown -R developer:developer /blazegraph-data

--- a/builds/deploy/triple-store/backend/Dockerfile
+++ b/builds/deploy/triple-store/backend/Dockerfile
@@ -26,4 +26,4 @@ RUN rm /pkt-data/PheKnowLator_Subclass_InverseRelations_NotClosed_NoOWL_OWLNETS.
 RUN chown -R developer:developer /blazegraph-data
 RUN chown -R developer:developer /home/developer
 USER developer
-CMD ["java", "-server", "-Xmx10g", "-jar", "-Dbigdata.propertyFile=/home/developer/blazegraph/conf/RWStore.properties", "-Djetty.start.timeout=3600000", "/home/developer/blazegraph/blazegraph.jar"]
+CMD ["java", "-server", "-Xmx32g", "-jar", "-Dbigdata.propertyFile=/home/developer/blazegraph/conf/RWStore.properties", "-Djetty.start.timeout=3600000", "/home/developer/blazegraph/blazegraph.jar"]

--- a/builds/deploy/triple-store/backend/RWStore.properties
+++ b/builds/deploy/triple-store/backend/RWStore.properties
@@ -1,0 +1,55 @@
+#
+# Note: These options are applied when the journal and the triple store are
+# first created.
+
+##
+## Journal options.
+##
+
+# The backing file. This contains all your data.  You want to put this someplace
+# safe.  The default locator will wind up in the directory from which you start
+# your servlet container.
+com.bigdata.journal.AbstractJournal.file=/blazegraph-data/bigdata.jnl
+
+# The persistence engine.  Use 'Disk' for the WORM or 'DiskRW' for the RWStore.
+com.bigdata.journal.AbstractJournal.bufferMode=DiskRW
+
+# Setup for the RWStore recycler rather than session protection.
+com.bigdata.service.AbstractTransactionService.minReleaseAge=1
+
+# Enable group commit. See http://wiki.blazegraph.com/wiki/index.php/GroupCommit
+# Note: Group commit is a beta feature in BlazeGraph release 1.5.1.
+#com.bigdata.journal.Journal.groupCommit=true
+
+com.bigdata.btree.writeRetentionQueue.capacity=4000
+com.bigdata.btree.BTree.branchingFactor=128
+
+# 200M initial extent.
+com.bigdata.journal.AbstractJournal.initialExtent=209715200
+com.bigdata.journal.AbstractJournal.maximumExtent=209715200
+
+
+com.bigdata.rdf.sparql.ast.QueryHints.analytic=true 
+# 20G query max memory
+com.bigdata.rdf.sparql.ast.QueryHints.analyticMaxMemoryPerQuery=21474836480 
+
+##
+## Setup for QUADS mode without the full text index.
+##
+com.bigdata.rdf.sail.truthMaintenance=false
+com.bigdata.rdf.store.AbstractTripleStore.quads=true
+com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false
+com.bigdata.rdf.store.AbstractTripleStore.textIndex=false
+com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms
+
+# Bump up the branching factor for the lexicon indices on the default kb.
+com.bigdata.namespace.kb.lex.com.bigdata.btree.BTree.branchingFactor=400
+
+# Bump up the branching factor for the statement indices on the default kb.
+com.bigdata.namespace.kb.spo.com.bigdata.btree.BTree.branchingFactor=1024
+
+# Uncomment to enable collection of OS level performance counters.  When
+# collected they will be self-reported through the /counters servlet and
+# the workbench "Performance" tab.
+#
+# com.bigdata.journal.Journal.collectPlatformStatistics=true

--- a/builds/deploy/triple-store/backend/log4j.properties
+++ b/builds/deploy/triple-store/backend/log4j.properties
@@ -1,0 +1,111 @@
+#
+# NOTE: this log4j configuration file was downloaded from: https://raw.githubusercontent.com/blazegraph/database/master/bigdata-perf/bsbm3/log4j.properties
+#
+# Default log4j configuration. See the individual classes for the
+# specific loggers, but generally they are named for the class in
+# which they are defined.
+
+# Default log4j configuration for testing purposes.
+#
+# You probably want to set the default log level to ERROR.
+#
+log4j.rootCategory=WARN, dest1
+#log4j.rootCategory=WARN, dest2
+
+# Loggers.
+# Note: logging here at INFO or DEBUG will significantly impact throughput!
+#log4j.logger.com.bigdata=INFO
+
+log4j.logger.com.bigdata.LRUNexus=INFO
+#log4j.logger.com.bigdata.rdf.sail.BigdataSail=INFO
+#log4j.logger.com.bigdata.rdf.sail.BigdataEvaluationStrategyImpl3=INFO
+log4j.logger.com.bigdata.rdf.sail.webapp.NanoSparqlServer=INFO
+log4j.logger.com.bigdata.rdf.sail.webapp.BigdataRDFServletContextListener=INFO
+log4j.logger.com.bigdata.relation.accesspath.BlockingBuffer=ERROR
+log4j.logger.com.bigdata.rdf.store.DataLoader=INFO
+
+# dest1
+log4j.appender.dest1=org.apache.log4j.ConsoleAppender
+log4j.appender.dest1.layout=org.apache.log4j.PatternLayout
+log4j.appender.dest1.layout.ConversionPattern=%-5p: %F:%L: %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-5p: %r %l: %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-5p: %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+#log4j.appender.dest1.layout.ConversionPattern=%-4r(%d) [%t] %-5p %c(%l:%M) %x - %m%n
+
+# dest2 includes the thread name and elapsed milliseconds.
+# Note: %r is elapsed milliseconds.
+# Note: %t is the thread name.
+# See http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
+log4j.appender.dest2=org.apache.log4j.ConsoleAppender
+log4j.appender.dest2.layout=org.apache.log4j.PatternLayout
+log4j.appender.dest2.layout.ConversionPattern=%-5p: %r %X{hostname} %X{serviceUUID} %X{taskname} %X{timestamp} %X{resources} %t %l: %m%n
+
+## 
+# Rule execution log. This is a formatted log file (comma delimited).
+#log4j.logger.com.bigdata.relation.rule.eval.RuleLog=INFO,ruleLog
+log4j.additivity.com.bigdata.relation.rule.eval.RuleLog=false
+log4j.appender.ruleLog=org.apache.log4j.FileAppender
+log4j.appender.ruleLog.Threshold=ALL
+log4j.appender.ruleLog.File=rules.log
+log4j.appender.ruleLog.Append=true
+log4j.appender.ruleLog.BufferedIO=true
+log4j.appender.ruleLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.ruleLog.layout.ConversionPattern=%m
+
+## 
+# Summary query evaluation log (tab delimited file). Uncomment the next line to enable.
+#log4j.logger.com.bigdata.bop.engine.QueryLog=INFO,queryLog
+log4j.additivity.com.bigdata.bop.engine.QueryLog=false
+log4j.appender.queryLog=org.apache.log4j.FileAppender
+log4j.appender.queryLog.Threshold=ALL
+log4j.appender.queryLog.File=queryLog.csv
+log4j.appender.queryLog.Append=true
+log4j.appender.queryLog.BufferedIO=true
+log4j.appender.queryLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.queryLog.layout.ConversionPattern=%m
+
+## 
+# BOp run state trace (tab delimited file).  Uncomment the next line to enable.
+#log4j.logger.com.bigdata.bop.engine.RunState$TableLog=INFO,queryRunStateLog
+log4j.additivity.com.bigdata.bop.engine.RunState$TableLog=false
+log4j.appender.queryRunStateLog=org.apache.log4j.FileAppender
+log4j.appender.queryRunStateLog.Threshold=ALL
+log4j.appender.queryRunStateLog.File=queryRunState.log
+log4j.appender.queryRunStateLog.Append=true
+log4j.appender.queryRunStateLog.BufferedIO=true
+log4j.appender.queryRunStateLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.queryRunStateLog.layout.ConversionPattern=%m
+
+## 
+# Solutions trace (tab delimited file).  Uncomment the next line to enable.
+#log4j.logger.com.bigdata.bop.engine.SolutionsLog=INFO,solutionsLog
+log4j.additivity.com.bigdata.bop.engine.SolutionsLog=false
+log4j.appender.solutionsLog=org.apache.log4j.ConsoleAppender
+#log4j.appender.solutionsLog=org.apache.log4j.FileAppender
+log4j.appender.solutionsLog.Threshold=ALL
+log4j.appender.solutionsLog.File=solutions.csv
+log4j.appender.solutionsLog.Append=true
+# I find that it is nicer to have this unbuffered since you can see what
+# is going on and to make sure that I have complete rule evaluation logs
+# on shutdown.
+log4j.appender.solutionsLog.BufferedIO=false
+log4j.appender.solutionsLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.solutionsLog.layout.ConversionPattern=SOLUTION:\t%m
+
+## 
+# SPARQL query trace (plain text file).  Uncomment 2nd line to enable.
+log4j.logger.com.bigdata.rdf.sparql.ast.eval.ASTEvalHelper=WARN
+#log4j.logger.com.bigdata.rdf.sparql.ast.eval.ASTEvalHelper=INFO,sparqlLog
+log4j.additivity.com.bigdata.rdf.sparql.ast.eval.ASTEvalHelper=false
+log4j.appender.sparqlLog=org.apache.log4j.ConsoleAppender
+#log4j.appender.sparqlLog=org.apache.log4j.FileAppender
+log4j.appender.sparqlLog.Threshold=ALL
+log4j.appender.sparqlLog.File=sparql.txt
+log4j.appender.sparqlLog.Append=true
+# I find that it is nicer to have this unbuffered since you can see what
+# is going on and to make sure that I have complete rule evaluation logs
+# on shutdown.
+log4j.appender.sparqlLog.BufferedIO=false
+log4j.appender.sparqlLog.layout=org.apache.log4j.PatternLayout
+log4j.appender.sparqlLog.layout.ConversionPattern=#----------%d-----------tx=%X{tx}\n%m\n

--- a/builds/deploy/triple-store/backend/override-web.xml
+++ b/builds/deploy/triple-store/backend/override-web.xml
@@ -1,3 +1,5 @@
+<!--file is added to ensure that end point is read-only-->
+<!--source: https://sourceforge.net/p/bigdata/mailman/message/35119798/--> 
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/builds/deploy/triple-store/backend/override-web.xml
+++ b/builds/deploy/triple-store/backend/override-web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaeehttp://java.sun.com/xml/ns/javaee/web-app_3_1.xsd"
+    version="3.1">
+  <context-param>
+   <description>When true, the REST API will not permit mutation operations.</description>
+   <param-name>readOnly</param-name>
+   <param-value>true</param-value>
+  </context-param>
+</web-app>

--- a/builds/deploy/triple-store/backend/pom-blazegraph-loader.xml
+++ b/builds/deploy/triple-store/backend/pom-blazegraph-loader.xml
@@ -1,0 +1,97 @@
+<!-- The POM invokes an OWLTools command that will load all ontology imports 
+	and output a single file that includes the source ontology and the content 
+	of all imported ontologies. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>edu.ucdenver.ccp</groupId>
+	<artifactId>blazegraph-bulk-loader</artifactId>
+	<packaging>pom</packaging>
+	<version>1.0</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<sesame.version>2.7.12</sesame.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.blazegraph</groupId>
+			<artifactId>bigdata-core</artifactId>
+			<version>2.1.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openrdf.sesame</groupId>
+			<artifactId>sesame-runtime</artifactId>
+			<version>${sesame.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openrdf.sesame</groupId>
+			<artifactId>sesame-rio-api</artifactId>
+			<version>${sesame.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.0.2</version>
+				<executions>
+					<execution>
+						<id>build-classpath</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>build-classpath</goal>
+						</goals>
+						<configuration>
+							<!-- configure the plugin here -->
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.1</version>
+				<configuration>
+					<executable>java</executable>
+					<arguments>
+						<argument>-Xmx7G</argument>
+						<argument>-DentityExpansionLimit=4086000</argument>
+						<argument>-Djava.awt.headless=true</argument>
+						<argument>-DlauncherDir=${launchDir}</argument>
+						<argument>-Dlog4j.configuration=file:${log4j_properties_file}</argument>
+						<argument>-classpath</argument>
+						<classpath />
+						<argument>com.bigdata.rdf.store.DataLoader</argument>
+						<argument>-verbose</argument>
+						<argument>-defaultGraph</argument>
+						<argument>${default_graph}</argument>
+						<argument>-format</argument>
+						<argument>${format}</argument>
+						<argument>-namespace</argument>
+						<argument>${repo_name}</argument>
+						<argument>${property_file}</argument>
+						<argument>${file_to_load}</argument> <!-- can be a list of files to load or a single file or directory -->
+					</arguments>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+
+
+</project>

--- a/builds/deploy/triple-store/backend/run-loader.sh
+++ b/builds/deploy/triple-store/backend/run-loader.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# NOTE: input arguments must be absolute paths
+
+function print_usage {
+    echo "Usage:"
+    echo "$(basename $0) [OPTIONS]"
+    echo "  [-g <default graph>]: The default graph to use for this load."
+    echo "  [-f <format>]: The format of the incoming triples."
+    echo "  [-r <repository name>]: The name of the repository (in blazegraph terminology, the 'namespace')"
+    echo "  [-p <blazegraph properties file>]: MUST BE ABSOLUTE PATH. The path to the blazegraph properties file."
+    echo "  [-l <file-to-load>]: MUST BE ABSOLUTE PATH. The path to the file to load. Note this can be multiple files space-delimited and can also be a directory."
+    echo "  [-z <log4j properties file>]: MUST BE ABSOLUTE PATH. The path to the log4j properties file."
+    echo "  [-m <maven>]: MUST BE ABSOLUTE PATH. The path to the mvn command."
+}
+
+while getopts "z:g:f:r:p:l:m:h" OPTION; do
+    case $OPTION in
+        # The default graph to use for this load
+        g) DEFAULT_GRAPH=$OPTARG
+           ;;
+        # The format of the incoming triples
+        f) FORMAT=$OPTARG
+           ;;
+        # the name of the repository (in blazegraph terminology, the 'namespace')
+        r) REPO_NAME=$OPTARG
+           ;;
+        # the path to the blazegraph properties file
+        p) BLAZEGRAPH_PROPERTIES_FILE=$OPTARG
+           ;;
+        # the path to the file to load. Note this can be multiple files space-delimited and can also be a directory
+        l) FILE_TO_LOAD=$OPTARG
+           ;;
+        # The path to the Apache Maven command
+        m) MAVEN=$OPTARG
+           ;;
+        # The path to the log4j properties file
+        z) LOG4J_PROPERTIES_FILE=$OPTARG
+           ;;
+        # HELP!
+        h) print_usage; exit 0
+           ;;
+    esac
+done
+
+if [[ -z ${DEFAULT_GRAPH} || -z ${FORMAT} || -z ${REPO_NAME} || -z ${BLAZEGRAPH_PROPERTIES_FILE} || -z ${FILE_TO_LOAD} || -z ${MAVEN} || -z ${LOG4J_PROPERTIES_FILE} ]]; then
+	echo "missing input arguments!!!!!"
+	echo "default graph: ${DEFAULT_GRAPH}"
+	echo "format: ${FORMAT}"
+	echo "repo name: ${REPO_NAME}"
+	echo "blazegraph properties file: ${BLAZEGRAPH_PROPERTIES_FILE}"
+	echo "file-to-load: ${FILE_TO_LOAD}"
+    echo "log4j properties file: ${LOG4J_PROPERTIES_FILE}"
+	echo "maven: ${MAVEN}"
+    print_usage
+    exit 1
+fi
+
+#if ! [[ -e README.md ]]; then
+#    echo "Please run from the root of the project."
+#    exit 1
+#fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+$MAVEN -e -f ${DIR}/pom-blazegraph-loader.xml exec:exec \
+        -Ddefault_graph=${DEFAULT_GRAPH} \
+        -Dformat=${FORMAT} \
+        -Drepo_name=${REPO_NAME} \
+        -Dproperty_file=${BLAZEGRAPH_PROPERTIES_FILE} \
+        -Dfile_to_load=${FILE_TO_LOAD} \
+        -Dlog4j_properties_file=${LOG4J_PROPERTIES_FILE}

--- a/builds/deploy/triple-store/docker-compose.yml
+++ b/builds/deploy/triple-store/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "80:3000"
     environment:
       - SPARQL_BACKEND=http://backend:9999/blazegraph/namespace/pheknowlator/sparql
+      - MAX_LIMIT=5000000
   backend:
     build: ./backend
     ports:

--- a/builds/deploy/triple-store/docker-compose.yml
+++ b/builds/deploy/triple-store/docker-compose.yml
@@ -2,12 +2,12 @@ version: "3"
 services:
   api:
     image: dbcls/sparql-proxy
-    ports:
-      - "80:3000"
+    # ports:
+    #   - "3000:3000"
     environment:
       - SPARQL_BACKEND=http://backend:9999/blazegraph/namespace/pheknowlator/sparql
       - MAX_LIMIT=5000000
   backend:
     build: ./backend
     ports:
-      - "8889:9999"
+      - "80:9999"

--- a/builds/deploy/triple-store/docker-compose.yml
+++ b/builds/deploy/triple-store/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  api:
+    image: dbcls/sparql-proxy
+    ports:
+      - "80:3000"
+    environment:
+      - SPARQL_BACKEND=http://backend:9999/blazegraph/namespace/pheknowlator/sparql
+  backend:
+    build: ./backend
+    ports:
+      - "8889:9999"


### PR DESCRIPTION
An initial commit of files to facilitate a SPARQL endpoint for PheKnowLator data. The endpoint uses the DBCLS sparql-proxy web app as the front end and serves triples from a Blazegraph backend.

**Note: This PR is not ready to be merged** as it currently hosts cl.owl and not the pkt data. Once the bucket path for the pkt data is known, it needs to be added to the Dockerfile.

Related to issue #69. 