### PR TITLE
🪓  Splitting Monthly Build Script

### DIFF
--- a/.github/workflows/kg-build-part1.yml
+++ b/.github/workflows/kg-build-part1.yml
@@ -1,0 +1,47 @@
+name:  KG Build - Part 1
+on:
+  schedule:
+    - cron: '0 0 1 * *'  # runs at 00:00:00 UTC on the first day of each month
+env:
+  PROJECT_ID: ${{ secrets.GCE_PROJECT }}
+  GCS_SERVICE_ACCOUNT: ${{ secrets.GCE_SA_KEY }}
+
+jobs:
+  pkt-build-phase-1-2:
+    name: KG Build Phases 1-2
+    runs-on: ubuntu-latest
+    env:
+      DOCKERFILE: builds/Dockerfile.phases12
+      GCE_MACHINE_TYPE: n1-highmem-16
+      GCE_REGION: us-central1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install Requirements and Dependencies
+        run: pip install -r builds/build_requirements.txt pkt_kg
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          service_account_key: ${{ secrets.GCE_SA_KEY }}
+          project_id: ${{ secrets.GCE_PROJECT }}
+      - name: Configure Docker Authentication
+        run: gcloud --quiet auth configure-docker
+      - name: Build Docker Image
+        run: docker build --tag "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA" -f "$DOCKERFILE" ./builds
+      - name: Publish Docker Image to Google Container Registry
+        run: docker push "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
+      - name: Prepare Temp Build Directory in PKT Google Cloud Storage Bucket
+        run: gsutil cp gs://pheknowlator/README.txt gs://pheknowlator/temp_build_inprogress/
+      - name: Submit Build Job to AI-Platform
+        run: |-
+            gcloud ai-platform jobs submit training "pkt_builder_phases_1_2_$GITHUB_SHA" \
+            --scale-tier custom --master-machine-type "$GCE_MACHINE_TYPE" --region "$GCE_REGION" \
+            --master-image-uri "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
+      - name: Monitor Build
+        run: python builds/job_monitoring.py --gce_type reg --phase 1 --sleep 60 --gcs_dir '' --project '' --job ''

--- a/.github/workflows/kg-build-part2.yml
+++ b/.github/workflows/kg-build-part2.yml
@@ -1,51 +1,12 @@
-name: Build and Deploy to Google Compute Engine
-on: push
-#  schedule:
-#    - cron: '0 0 1 * *'  # runs at 00:00:00 UTC on the first day of each month
+name: KG Build - Part 2
+on:
+  schedule:
+    - cron: '0 0 2 * *'  # runs at 00:00:00 UTC on the first day of each month
 env:
   PROJECT_ID: ${{ secrets.GCE_PROJECT }}
   GCS_SERVICE_ACCOUNT: ${{ secrets.GCE_SA_KEY }}
 
 jobs:
-#  pkt-build-phase-1-2:
-#    name: KG Build Phases 1-2
-#    runs-on: ubuntu-latest
-#    env:
-#      DOCKERFILE: builds/Dockerfile.phases12
-#      GCE_MACHINE_TYPE: n1-highmem-16
-#      GCE_REGION: us-central1
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#        with:
-#          ref: master
-#      - name: Setup Python
-#        uses: actions/setup-python@v2
-#        with:
-#          python-version: 3.6
-#      - name: Install Requirements and Dependencies
-#        run: pip install -r builds/build_requirements.txt pkt_kg
-#      - uses: google-github-actions/setup-gcloud@master
-#        with:
-#          version: '290.0.1'
-#          service_account_key: ${{ secrets.GCE_SA_KEY }}
-#          project_id: ${{ secrets.GCE_PROJECT }}
-#      - name: Configure Docker Authentication
-#        run: gcloud --quiet auth configure-docker
-#      - name: Build Docker Image
-#        run: docker build --tag "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA" -f "$DOCKERFILE" ./builds
-#      - name: Publish Docker Image to Google Container Registry
-#        run: docker push "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
-#      - name: Prepare Temp Build Directory in PKT Google Cloud Storage Bucket
-#        run: gsutil cp gs://pheknowlator/README.txt gs://pheknowlator/temp_build_inprogress/
-#      - name: Submit Build Job to AI-Platform
-#        run: |-
-#            gcloud ai-platform jobs submit training "pkt_builder_phases_1_2_$GITHUB_SHA" \
-#            --scale-tier custom --master-machine-type "$GCE_MACHINE_TYPE" --region "$GCE_REGION" \
-#            --master-image-uri "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
-#      - name: Monitor Build
-#        run: python builds/job_monitoring.py --gce_type reg --phase 1 --sleep 60 --gcs_dir '' --project '' --job ''
-
   pkt-build-phase3-job1:
 #    needs: pkt-build-phase-1-2
     name: KG Build Phase 3 - Job 1 (Subclass + RelationsOnly + OWL/OWL-NETS)

--- a/.github/workflows/kg-build.yml
+++ b/.github/workflows/kg-build.yml
@@ -7,47 +7,47 @@ env:
   GCS_SERVICE_ACCOUNT: ${{ secrets.GCE_SA_KEY }}
 
 jobs:
-  pkt-build-phase-1-2:
-    name: KG Build Phases 1-2
-    runs-on: ubuntu-latest
-    env:
-      DOCKERFILE: builds/Dockerfile.phases12
-      GCE_MACHINE_TYPE: n1-highmem-16
-      GCE_REGION: us-central1
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: master
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-      - name: Install Requirements and Dependencies
-        run: pip install -r builds/build_requirements.txt pkt_kg
-      - uses: google-github-actions/setup-gcloud@master
-        with:
-          version: '290.0.1'
-          service_account_key: ${{ secrets.GCE_SA_KEY }}
-          project_id: ${{ secrets.GCE_PROJECT }}
-      - name: Configure Docker Authentication
-        run: gcloud --quiet auth configure-docker
-      - name: Build Docker Image
-        run: docker build --tag "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA" -f "$DOCKERFILE" ./builds
-      - name: Publish Docker Image to Google Container Registry
-        run: docker push "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
-      - name: Prepare Temp Build Directory in PKT Google Cloud Storage Bucket
-        run: gsutil cp gs://pheknowlator/README.txt gs://pheknowlator/temp_build_inprogress/
-      - name: Submit Build Job to AI-Platform
-        run: |-
-            gcloud ai-platform jobs submit training "pkt_builder_phases_1_2_$GITHUB_SHA" \
-            --scale-tier custom --master-machine-type "$GCE_MACHINE_TYPE" --region "$GCE_REGION" \
-            --master-image-uri "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
-      - name: Monitor Build
-        run: python builds/job_monitoring.py --gce_type reg --phase 1 --sleep 60 --gcs_dir '' --project '' --job ''
+#  pkt-build-phase-1-2:
+#    name: KG Build Phases 1-2
+#    runs-on: ubuntu-latest
+#    env:
+#      DOCKERFILE: builds/Dockerfile.phases12
+#      GCE_MACHINE_TYPE: n1-highmem-16
+#      GCE_REGION: us-central1
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#        with:
+#          ref: master
+#      - name: Setup Python
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.6
+#      - name: Install Requirements and Dependencies
+#        run: pip install -r builds/build_requirements.txt pkt_kg
+#      - uses: google-github-actions/setup-gcloud@master
+#        with:
+#          version: '290.0.1'
+#          service_account_key: ${{ secrets.GCE_SA_KEY }}
+#          project_id: ${{ secrets.GCE_PROJECT }}
+#      - name: Configure Docker Authentication
+#        run: gcloud --quiet auth configure-docker
+#      - name: Build Docker Image
+#        run: docker build --tag "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA" -f "$DOCKERFILE" ./builds
+#      - name: Publish Docker Image to Google Container Registry
+#        run: docker push "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
+#      - name: Prepare Temp Build Directory in PKT Google Cloud Storage Bucket
+#        run: gsutil cp gs://pheknowlator/README.txt gs://pheknowlator/temp_build_inprogress/
+#      - name: Submit Build Job to AI-Platform
+#        run: |-
+#            gcloud ai-platform jobs submit training "pkt_builder_phases_1_2_$GITHUB_SHA" \
+#            --scale-tier custom --master-machine-type "$GCE_MACHINE_TYPE" --region "$GCE_REGION" \
+#            --master-image-uri "gcr.io/$PROJECT_ID/pkt_builder_phases_1_2_$GITHUB_SHA-image:$GITHUB_SHA"
+#      - name: Monitor Build
+#        run: python builds/job_monitoring.py --gce_type reg --phase 1 --sleep 60 --gcs_dir '' --project '' --job ''
 
   pkt-build-phase3-job1:
-    needs: pkt-build-phase-1-2
+#    needs: pkt-build-phase-1-2
     name: KG Build Phase 3 - Job 1 (Subclass + RelationsOnly + OWL/OWL-NETS)
     runs-on: ubuntu-latest
     timeout-minutes: 3000
@@ -101,7 +101,7 @@ jobs:
 #         run: gcloud compute instances delete "$GCE_JOB_NAME" --zone="$GCE_ZONE"
 
   pkt-build-phase3-job2:
-    needs: pkt-build-phase-1-2
+#    needs: pkt-build-phase-1-2
     name: KG Build Phase 3 - Job 2 (Subclass + InverseRelations + OWL/OWL-NETS)
     runs-on: ubuntu-latest
     timeout-minutes: 3000
@@ -158,7 +158,7 @@ jobs:
 #         run: gcloud compute instances delete "$GCE_JOB_NAME" --zone="$GCE_ZONE"
 
   pkt-build-phase3-job3:
-    needs: pkt-build-phase-1-2
+#    needs: pkt-build-phase-1-2
     name: KG Build Phase 3 - Job 3 (Instance + RelationsOnly + OWL/OWL-NETS)
     runs-on: ubuntu-latest
     timeout-minutes: 3000
@@ -212,7 +212,7 @@ jobs:
 #         run: gcloud compute instances delete "$GCE_JOB_NAME" --zone="$GCE_ZONE"
 
   pkt-build-phase3-job4:
-    needs: pkt-build-phase-1-2
+#    needs: pkt-build-phase-1-2
     name: KG Build Phase 3 - Job 4 (Instance + InverseRelations + OWL/OWL-NETS)
     runs-on: ubuntu-latest
     timeout-minutes: 3000

--- a/.github/workflows/kg-build.yml
+++ b/.github/workflows/kg-build.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy to Google Compute Engine
-on:  
-  schedule:
-    - cron: '0 0 1 * *'  # runs at 00:00:00 UTC on the first day of each month
+on: push
+#  schedule:
+#    - cron: '0 0 1 * *'  # runs at 00:00:00 UTC on the first day of each month
 env:
   PROJECT_ID: ${{ secrets.GCE_PROJECT }}
   GCS_SERVICE_ACCOUNT: ${{ secrets.GCE_SA_KEY }}


### PR DESCRIPTION
### Functionality
This PR splits the original build script into two parts. 

### Reason
Currently, the first part of the monthly build routine takes well over the 6 hours allotted by GitHub Actions, which never triggers the second part of the build. This split schedules part 1 for the first of every month and part two for the second of every month. Unless a bug is found, this will enable the builds to complete with less manual oversight and less delay in each build.