### PR TITLE
removed dependance on PRO Endpoint

### DIFF
--- a/notebooks/Data_Preparation.ipynb
+++ b/notebooks/Data_Preparation.ipynb
@@ -180,7 +180,10 @@
     "ontology_data_location = '../resources/ontologies/'\n",
     "\n",
     "# owltools location\n",
-    "owltools_location = '../pkt_kg/libs/owltools'"
+    "owltools_location = '../pkt_kg/libs/owltools'\n",
+    "\n",
+    "# obo spacespace\n",
+    "obo = Namespace('http://purl.obolibrary.org/obo/')"
    ]
   },
   {
@@ -3363,32 +3366,7 @@
    "metadata": {},
    "source": [
     "_Identify Human Proteins_   \n",
-    "A list of human proteins is obtained by querying the ontology to return all ontology classes `only_in_taxon some Homo sapiens`. To expedite the query time, the following SPARQL query is run from the [ProConsortium](https://proconsortium.org/pro_sparql.shtml) SPARQL endpoint: \n",
-    "\n",
-    "___\n",
-    "\n",
-    "\n",
-    "```SPARQL\n",
-    "PREFIX obo: <http://purl.obolibrary.org/obo/>\n",
-    "\n",
-    "SELECT ?PRO_term\n",
-    "FROM <http://purl.obolibrary.org/obo/pr>\n",
-    "WHERE {\n",
-    "       ?PRO_term rdf:type owl:Class .\n",
-    "       ?PRO_term rdfs:subClassOf ?restriction .\n",
-    "       ?restriction owl:onProperty obo:RO_0002160 .\n",
-    "       ?restriction owl:someValuesFrom obo:NCBITaxon_9606 .\n",
-    "\n",
-    "       # use this to filter-out things like hgnc ids\n",
-    "       FILTER (regex(?PRO_term,\"http://purl.obolibrary.org/obo/*\")) .\n",
-    "}\n",
-    "\n",
-    "```\n",
-    "\n",
-    "___\n",
-    "\n",
-    "\n",
-    "**NOTE.** Be sure to obtain a new URL from the [ProConsortium](https://proconsortium.org/pro_sparql.shtml) when rebuilding to ensure you are getting the most up-to-date data."
+    "A list of human proteins is obtained by querying the ontology to return all ontology classes `only_in_taxon some Homo sapiens`."
    ]
   },
   {
@@ -3396,33 +3374,22 @@
    "metadata": {},
    "source": [
     "*Approach 1 - Query Loaded Graph to Obtain Human Protein Classes*  \n",
-    "This approach is very slow and should only be used when there is no internet or when the PRO Consortium's SPARQL Endpoint is not functional."
+    "Does not require using external resources or SPARQL Endpoints. This is the preferred approach."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "code_folding": [
-     0
-    ]
+    "code_folding": []
    },
    "outputs": [],
    "source": [
-    "# slower approach when no internet access available\n",
-    "# human_pro_classes = graph.query(\n",
-    "#     \"\"\"SELECT DISTINCT ?PRO_term\n",
-    "#            WHERE {\n",
-    "#               ?PRO_term rdf:type owl:Class .\n",
-    "#               ?PRO_term rdfs:subClassOf ?restriction .\n",
-    "#               ?restriction owl:onProperty obo:RO_0002160 .\n",
-    "#               ?restriction owl:someValuesFrom obo:NCBITaxon_9606 .}\n",
-    "#            \"\"\", initNs={'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',\n",
-    "#                         'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',\n",
-    "#                         'owl': 'http://www.w3.org/2002/07/owl#',\n",
-    "#                         'obo': 'http://purl.obolibrary.org/obo/'}) \n",
+    "human_classes_restriction = list(pr_graph.triples((None, OWL.someValuesFrom, obo.NCBITaxon_9606)))\n",
+    "human_classes = [list(pr_graph.subjects(RDFS.subClassOf, x[0])) for x in human_classes_restriction]\n",
+    "human_pro_classes = list(str(i) for j in human_classes for i in j if 'PR_' in str(i))\n",
     "\n",
-    "# print('There are {} edges in the ontology (date:{})'.format(len(human_pro_classes), datetime.datetime.now().strftime('%m/%d/%Y')))"
+    "print('There are {} edges in the ontology (date:{})'.format(len(human_pro_classes), datetime.datetime.now().strftime('%m/%d/%Y')))"
    ]
   },
   {
@@ -3430,26 +3397,28 @@
    "metadata": {},
    "source": [
     "*Approach 2 - Query PRO Consortium SPARQL Endpoint to Obtain Human Protein Classes*  \n",
-    "This approach is much faster than Approach 1 and should be used in place of it,"
+    "This approach should only be used when the PRO endpoint is not limiting the number of results that are returned. As of `October 2021`, this was happening so please use *Approach 1* which is guaranteed to return the correct results."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "code_folding": []
+   },
    "outputs": [],
    "source": [
-    "# download data\n",
-    "url = 'https://sparql.proconsortium.org/virtuoso/sparql?query=PREFIX+obo%3A+%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2F%3E%0D%0A%0D%0ASELECT+%3FPRO_term%0D%0AFROM+%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fpr%3E%0D%0AWHERE+%7B%0D%0A+++++++%3FPRO_term+rdf%3Atype+owl%3AClass+.%0D%0A+++++++%3FPRO_term+rdfs%3AsubClassOf+%3Frestriction+.%0D%0A+++++++%3Frestriction+owl%3AonProperty+obo%3ARO_0002160+.%0D%0A+++++++%3Frestriction+owl%3AsomeValuesFrom+obo%3ANCBITaxon_9606+.%0D%0A%0D%0A+++++++%23+use+this+to+filter-out+things+like+hgnc+ids%0D%0A+++++++FILTER+%28regex%28%3FPRO_term%2C%22http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2F*%22%29%29+.%0D%0A%7D&format=text%2Fhtml&debug='\n",
-    "if not os.path.exists(unprocessed_data_location + 'human_pro_classes.html'):\n",
-    "    data_downloader(url, unprocessed_data_location, 'human_pro_classes.html')\n",
+    "# # download data\n",
+    "# url = 'https://sparql.proconsortium.org/virtuoso/sparql?query=PREFIX+obo%3A+%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2F%3E%0D%0A%0D%0ASELECT+%3FPRO_term%0D%0AFROM+%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fpr%3E%0D%0AWHERE+%7B%0D%0A+++++++%3FPRO_term+rdf%3Atype+owl%3AClass+.%0D%0A+++++++%3FPRO_term+rdfs%3AsubClassOf+%3Frestriction+.%0D%0A+++++++%3Frestriction+owl%3AonProperty+obo%3ARO_0002160+.%0D%0A+++++++%3Frestriction+owl%3AsomeValuesFrom+obo%3ANCBITaxon_9606+.%0D%0A%0D%0A+++++++%23+use+this+to+filter-out+things+like+hgnc+ids%0D%0A+++++++FILTER+%28regex%28%3FPRO_term%2C%22http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2F*%22%29%29+.%0D%0A%7D&format=text%2Fhtml&debug='\n",
+    "# if not os.path.exists(unprocessed_data_location + 'human_pro_classes.html'):\n",
+    "#     data_downloader(url, unprocessed_data_location, 'human_pro_classes.html')\n",
     "\n",
-    "# load data\n",
-    "df_list = pandas.read_html(unprocessed_data_location + 'human_pro_classes.html')\n",
+    "# # load data\n",
+    "# df_list = pandas.read_html(unprocessed_data_location + 'human_pro_classes.html')\n",
     "\n",
-    "# extract data from html table - pro classes only_in_taxon some Homo sapiens\n",
-    "human_pro_classes = list(df_list[-1]['PRO_term'])\n",
-    "print('There are {} edges in the ontology (date:{})'.format(len(human_pro_classes), datetime.datetime.now().strftime('%m/%d/%Y')))"
+    "# # extract data from html table - pro classes only_in_taxon some Homo sapiens\n",
+    "# human_pro_classes = list(df_list[-1]['PRO_term'])\n",
+    "# print('There are {} edges in the ontology (date:{})'.format(len(human_pro_classes), datetime.datetime.now().strftime('%m/%d/%Y')))"
    ]
   },
   {


### PR DESCRIPTION
#### Purpose  
This PR removes a dependency on the [PRO Consortium SPARQL Endpoint](https://sparql.proconsortium.org/virtuoso/sparql), which is used to identify human protein classes. It was discovered that the October build was missing metadata for more than 50,000 protein classes, which was caused by a new limit placed on this Endpoint. The code has been updated to remove this dependency.


This PR address a specific bug that was caught as part of investigating issue #118. A huge thank you to @sanyabt for her help in identifying and problem-solving this issue.