### PR TITLE
removing sparql query dependency

### DIFF
--- a/pkt_kg/metadata.py
+++ b/pkt_kg/metadata.py
@@ -216,19 +216,13 @@ class Metadata(object):
         pkt_url = 'https://github.com/callahantiff/PheKnowLator'
 
         # query ontology to obtain existing ontology annotations and remove them
-        results = graph.query(
-            """SELECT DISTINCT ?o ?p ?s
-                WHERE {
-                    ?o rdf:type owl:Ontology .
-                    ?o ?p ?s . }
-            """, initNs={'rdf': RDF, 'owl': OWL})
-        for res in results:
-            graph.remove(res)
+        results = list(graph.triples((list(graph.subjects(RDF.type, OWL.Ontology))[0], None, None)))
+        for res in results: graph.remove(res)
 
         # add new annotations
-        graph.add((URIRef(url + '.owl'), RDF.type, URIRef(OWL + 'Ontology')))
+        graph.add((URIRef(url + '.owl'), RDF.type, OWL.Ontology))
         graph.add((URIRef(url + '.owl'), URIRef(oboinowl + 'default-namespace'), Literal(filename)))
-        graph.add((URIRef(url + '.owl'), URIRef(OWL + 'versionIRI'), URIRef(pkt_url + '/wiki/' + self.kg_version)))
+        graph.add((URIRef(url + '.owl'), OWL.versionIRI, URIRef(pkt_url + '/wiki/' + self.kg_version)))
         graph.add((URIRef(url + '.owl'), RDFS.comment, Literal('PheKnowLator Release version ' + self.kg_version)))
         graph.add((URIRef(url + '.owl'), URIRef(oboinowl + 'date'), Literal(date_full)))
         graph.add((URIRef(url + '.owl'), RDFS.comment, Literal(authors)))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,7 +5,8 @@ import os.path
 import pickle
 import unittest
 
-from rdflib import Graph
+from rdflib import Graph, Namespace
+from rdflib.namespace import RDF, OWL
 from typing import Dict
 
 from pkt_kg.metadata import *
@@ -281,14 +282,7 @@ class TestMetadata(unittest.TestCase):
         updated_graph = self.metadata.adds_ontology_annotations(filename='tests/data/so_tests_file.owl', graph=graph)
 
         # check that the annotations were added
-        results = updated_graph.query(
-            """SELECT DISTINCT ?o ?p ?s
-                WHERE {
-                    ?o rdf:type owl:Ontology .
-                    ?o ?p ?s . }
-            """, initNs={'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-                         'owl': 'http://www.w3.org/2002/07/owl#'})
-
+        results = list(graph.triples((list(graph.subjects(RDF.type, OWL.Ontology))[0], None, None)))
         results_list = [str(x) for y in results for x in y]
         self.assertTrue(len(results_list) == 21)
         self.assertIn('https://pheknowlator.com/pheknowlator_file.owl', results_list)


### PR DESCRIPTION
### Purpose  
This PR updates a function in the `metadata.py` script removing the use the `rdflib` SPARQL query for a quicker solution, which is generator-based.