### PR TITLE
fixing none pred bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 |logo|
 
 
-|pip| |downloads|
+|pip|
 
 |github_action|  |ABRA|
 
@@ -397,10 +397,6 @@ Callahan TJ, Tripodi IJ, Hunter LE, Baumgartner WA. `A Framework for Automated C
 .. |pip| image:: https://img.shields.io/pypi/v/pkt-kg?label=PyPI&logo=pypi&style=social
     :target: https://pypi.org/project/pkt-kg/
     :alt: PyPI project
-
-.. |downloads| image:: https://pepy.tech/badge/pkt_kg
-    :target: https://pepy.tech/badge/pkt_kg
-    :alt: Pypi total project downloads
 
 .. |codacy| image:: https://app.codacy.com/project/badge/Grade/2cfa4ef5f9b6498da56afea0f5dadeed
     :target: https://www.codacy.com/gh/callahantiff/PheKnowLator/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=callahantiff/PheKnowLator&amp;utm_campaign=Badge_Grade

--- a/pkt_kg/__version__.py
+++ b/pkt_kg/__version__.py
@@ -1,2 +1,2 @@
 """Current version of package pkt_kg"""
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/pkt_kg/owlnets.py
+++ b/pkt_kg/owlnets.py
@@ -429,18 +429,9 @@ class OwlNets(object):
 
         The following ObjectProperties are returned for each of the following subject-object types:
             - if sub + obj are PATO terms + prop is None --> rdfs:subClassOf
-            - if sub + obj are not PATO terms + prop is None --> rdfs:subClassOf
             - elif sub is not a PATO term, but obj is a PATO term --> obo:RO_000086
             - elif prop is not None --> prop
             - else --> rdfs:subClassOf
-
-            - if sub + obj are PATO terms and property is none --> rdfs:subClassOf
-            - if sub + obj are NOT PATO terms and property is none --> rdfs:subClassOf
-            - obj is PATO term and property is none --> obo:RO_000086
-            - obj is PATO term and property is NOT none --> obo:RO_000086
-            - subj is a PATO term and property is none -->  RDFS.subClassOf
-            - subj is a PATO term and property is NOT none --> prop
-
 
         Args:
             sub: An rdflib.term object.
@@ -451,18 +442,14 @@ class OwlNets(object):
             An rdflib.term object that represents an owl:ObjectProperty.
         """
 
-        # if ('PATO' in sub and 'PATO' in obj) and prop is None: return RDFS.subClassOf
-        # elif 'PATO' not in sub and 'PATO' in obj: return obo.RO_0000086
-        # elif prop is None: return RDFS.subClassOf
-        # else: return prop
+        # extra verification to ensure None is properly caught (not needed but makes me feel better :P)
+        prop = None if prop is None or (prop is not None and prop.lower() == 'none') else prop
 
         if ('PATO' in sub and 'PATO' in obj) and prop is None: return RDFS.subClassOf
-        elif ('PATO' not in sub and 'PATO' not in obj) and prop is None: return RDFS.subClassOf
-        elif 'PATO' in obj and prop is None: return obo.RO_0000086
-        elif 'PATO' in obj and prop is not None: return obo.RO_0000086
-        elif 'PATO' in sub and prop is None: return RDFS.subClassOf
-        elif 'PATO' in sub and prop is not None: return prop
-        elif prop is None: return RDFS.subClassOf
+        elif 'PATO' not in sub and 'PATO' in obj: return obo.RO_0000086
+        elif prop is not None: return prop
+        else: return RDFS.subClassOf
+
 
     @staticmethod
     def parses_anonymous_axioms(edges: Dict, class_dict: Dict) -> Dict:


### PR DESCRIPTION
Thanks @sanyabt for pointing out that there was a bug in the `owlnets.py` file. The bug output triples with `None` as the predicate value. This error was caused by bad logic in the `returns_object_property()` function. This has now been repaired and fixed such that it is not possible to return `None` for predicates.

As a result, a new release will be made and pushed to PyPI. The version number will be bumped to `v3.1.1`.